### PR TITLE
fix: use DELETE journal mode for SQLite to support cloud sync

### DIFF
--- a/main.py
+++ b/main.py
@@ -355,7 +355,11 @@ class PromptManager:
         self._initialize_db()
 
     def _connect(self) -> sqlite3.Connection:
-        return sqlite3.connect(self.prompts_file)
+        conn = sqlite3.connect(self.prompts_file)
+        # Explicitly use DELETE journal mode for cloud sync compatibility (OneDrive, Dropbox, etc.)
+        # WAL mode creates extra -wal/-shm files that cause sync conflicts
+        conn.execute("PRAGMA journal_mode=DELETE")
+        return conn
 
     def _initialize_db(self) -> None:
         try:


### PR DESCRIPTION
## Problem

Cloud storage services (OneDrive, Dropbox, etc.) do not work well with SQLite WAL mode:
- WAL mode creates additional `-wal` and `-shm` files
- These auxiliary files cause sync conflicts
- Can lead to database corruption when syncing across devices

## Solution

Explicitly set `PRAGMA journal_mode=DELETE` in the database connection method. This ensures:

- No `-wal` or `-shm` files are created
- Database remains a single `.sqlite` file
- Clean synchronization with cloud services

## Testing

- Existing prompts database continues to work
- On first open, WAL-mode databases automatically convert to DELETE mode